### PR TITLE
Add required setting for signed requests.

### DIFF
--- a/numserver.com.custodian-record.json
+++ b/numserver.com.custodian-record.json
@@ -9,6 +9,7 @@
    "logoUrl":"",
    "description":"Configure a NUM custodian record for your domain name to prove that you are an administrator of the domain, for more info see: https://num.uk/modules/4",
    "variableDescription":"The user_hash variable is a SHA-1 hash of an identifier, e.g. email, domain or telephone number",   
+   "syncPubKeyDomain":"numserver.com",
    "records":[
       {
          "type":"TXT",

--- a/numserver.com.delegate-num-zone.json
+++ b/numserver.com.delegate-num-zone.json
@@ -8,7 +8,8 @@
    "sharedProviderName": true,
    "logoUrl":"",
    "description":"Delegate your Independent NUM Zone to the NUM Server. All DNS queries to '_num.example.com' will be answered by the NUM Server. Find out more about the NUM protocol at https://num.uk.",
-   "variableDescription":"The ns1-ns4 variables are nameserver IDs",   
+   "variableDescription":"The ns1-ns4 variables are nameserver IDs",
+   "syncPubKeyDomain":"numserver.com",
    "records":[
    {
       "type": "NS",


### PR DESCRIPTION
Since we're going sign our requests using a private key we have to tell the DNS provider where to find our public key. We do this using a `syncPubKeyDomain` value in the template and a `key` parameter on the request. The two are combined to give the DNS location of the public key.

My guess is that we'll store the key at `numserver.com` with a key name of `_dcpubkeyv1` so it would be `_dcpubkeyv1.numserver.com`. Let me know if you prefer a different location and/or key.

```
The Service provider must publish their public key and place it in a DNS TXT record in a domain
specified in the template in syncPubKeyDomain. To allow for key rotation, the host name of the
TXT record must be appended as another variable on the query string of the form:

key=_dcpubkeyv1
This example indicates that the public key can be found by doing a DNS query for a TXT record
called _dcpubkeyv1 in the domain specified in the syncPubKeyDomain from the template.
```

The format of the public key in DNS is described [here](https://github.com/Domain-Connect/spec/blob/master/Domain%20Connect%20Spec%20Draft.adoc#423-security-considerations).